### PR TITLE
add Mac OS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ issue: <a href="https://github.com/ChestnutHeng/Wudao-dict/issues/new">创建新
     sudo pip3 install bs4
     sudo pip3 install lxml
     ```
+    #### MacOS
+    ```
+    brew install python3
+    sudo easy_install pip
+    sudo pip install bs4
+    sudo pip install lxml
+    brew install bash-completion
+    ```
 
 2.  运行
     ```sh
@@ -118,6 +126,6 @@ Youdao is wudao, a powerful dict.
 * 修复了文件夹过大的问题，由263M缩小到80M左右。<a href="https://github.com/ChestnutHeng/Wudao-dict/issues/1"> issue #1: 文件夹大小</a>
 * 添加了更多的常用词和单复数形式
 * 取消了网络搜索功能，没有在本地找到时会自动进行网络搜索
-* 添加了tab补全的支持，对常用的1w词进行tab补全 <a href="https://github.com/ChestnutHeng/Wudao-dict/issues/15">issue #15: 模糊查询的支持</a>
+* 添加了bash终端的tab补全的支持，对常用的1w词进行tab补全 <a href="https://github.com/ChestnutHeng/Wudao-dict/issues/15">issue #15: 模糊查询的支持</a>
 * 添加了生词本功能，自动把查过的词和释义添加到生词本文件中
 * 优化了排版，同一单词不再截断换行了 #该功能因为转移字符的问题搁置 <a href="https://github.com/ChestnutHeng/Wudao-dict/issues/16">issue #16:避免在单词内换行</a>

--- a/wudao-dict/setup.sh
+++ b/wudao-dict/setup.sh
@@ -14,16 +14,25 @@ echo 'save_path=$PWD'>>./wd
 echo 'cd '$PWD >>./wd
 echo './wdd $*'>>./wd
 echo 'cd $save_path'>>./wd
-sudo cp ./wd /usr/bin/wd
-sudo chmod +x /usr/bin/wd
 
-# 添加自动补全
-sudo rm -f /etc/bash_completion.d/wd
-sudo cp wd_com /etc/bash_completion.d/wd
-. /etc/bash_completion.d/wd
+sysOS=`uname -s`
+if [ $sysOS == "Darwin" ];then
+    sudo cp ./wd /usr/local/bin/wd
+    sudo chmod +x /usr/local/bin/wd
+    # 添加bash自动补全
+    sudo rm -f /usr/local/etc/bash_completion.d/wd
+    sudo cp wd_com /usr/local/etc/bash_completion.d/wd
+    . /usr/local/etc/bash_completion.d/wd
+else
+    sudo cp ./wd /usr/bin/wd
+    sudo chmod +x /usr/bin/wd
+    # 添加bash_completion自动补全
+    sudo rm -f /etc/bash_completion.d/wd
+    sudo cp wd_com /etc/bash_completion.d/wd
+    . /etc/bash_completion.d/wd
+fi
 
 echo 'Setup Finished! '
 echo 'use wd [OPTION]... [WORD] to query the word.'
-echo '自动补全会在下次打开命令行时启用'
+echo '自动补全(仅支持bash)会在下次打开命令行时启用'
 echo '或者手动运行 source ~/.bashrc'
-

--- a/wudao-dict/uninstall.sh
+++ b/wudao-dict/uninstall.sh
@@ -1,11 +1,19 @@
 #!/bin/bash
 
 wd -k
-# 删除系统命令wd
-sudo rm -f /usr/bin/wd
 
-# 删除自动补全
-sudo rm -f /etc/bash_completion.d/wd
+sysOS=`uname -s`
+if [ $sysOS == "Darwin" ];then
+    # 删除系统命令wd
+    sudo rm -f /usr/local/bin/wd
+    # 删除自动补全
+    sudo rm -f /usr/local/etc/bash_completion.d/wd
+else
+    # 删除系统命令wd
+    sudo rm -f /usr/bin/wd
+    # 删除自动补全
+    sudo rm -f /etc/bash_completion.d/wd
+fi
 
 echo 'Uninstall Finished! '
 


### PR DESCRIPTION
I used to use the "**wudao-dict**" on Ubuntu. Now changed to mac OS, found that the "**wd**" is still cool , so adapted to the mac version. 
 I Just changed **setup.sh/uninstall.sh** actually, because the normal way for Mac OS is to prohibit any writes to /user/bin, so you need to change the script write path.I have passed several self-tests on my MacBook Pro.
thanks a lots ;-)

以前我在Ubuntu上用楼主的**wudao-dict**用得很爽。现在换了mac OS，发现还是楼主的**wd**好用，因此适配了一下mac版。
其实我只是改动了**setup.sh/uninstall.sh**，因为Mac OS正常途径是禁止任何对/user/bin的写入，所以需要改动一下脚本写入路径即可。已经在自己的MacBook Pro上通过了几次自测。
感谢楼主多年维护 ;-)